### PR TITLE
Fixed: import third-party packages after updating library path

### DIFF
--- a/playbook/basic/run.py
+++ b/playbook/basic/run.py
@@ -3,9 +3,6 @@
 import os
 import traceback
 
-# third-party
-from tcex.app_config.install_json import InstallJson
-
 # first-party
 from app_lib import AppLib
 
@@ -21,6 +18,7 @@ def run() -> None:
     # import modules after path has been updated
 
     # third-party
+    from tcex.app_config.install_json import InstallJson  # pylint: disable=import-outside-toplevel
     from tcex import TcEx  # pylint: disable=import-outside-toplevel
 
     # first-party

--- a/playbook/basic/run.py
+++ b/playbook/basic/run.py
@@ -18,8 +18,8 @@ def run() -> None:
     # import modules after path has been updated
 
     # third-party
-    from tcex.app_config.install_json import InstallJson  # pylint: disable=import-outside-toplevel
     from tcex import TcEx  # pylint: disable=import-outside-toplevel
+    from tcex.app_config.install_json import InstallJson  # pylint: disable=import-outside-toplevel
 
     # first-party
     from app import App  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
Import this tcex package after the library paths are updated so it can properly find the package.

Fixed this error when running the custom app based on this template:

```
Traceback (most recent call last):
  File "/opt/python3.6.15/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/python3.6.15/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "./__main__.py", line 3, in <module>
    from run import run
  File "./run.py", line 8, in <module>
    from tcex.app_config.install_json import InstallJson
ModuleNotFoundError: No module named 'tcex.app_config'
```
